### PR TITLE
Add secret key authentication and validation feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ data-encoding = "2.9.0"
 jsonschema = "0.30.0"
 sp-core = "36.1.0"
 clap = { version = "4.5", features = ["derive"] }
+blake3 = "1.8.2"


### PR DESCRIPTION
Before this commit anyone with the correct path was able to start the node, irrespective of whether the secret-key used to start the node matches or not. 
This commit stores the secret-key's Blake hash in the path under 'secret-key' file and validates against it whenever someone tries to use this path. 