### PR TITLE
Add gateway checks for nodeId and domains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "helpers",
     "node",
     "router",
-    "bin"
+    "bin",
+    "gateway"
 ]
 
 resolver = "2"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,3 +20,4 @@ regex = "1.11.1"
 
 core = { path = "../core" }
 helpers = { path = "../helpers" }
+gateway = { path = "../gateway" }

--- a/api/src/authors_handler.rs
+++ b/api/src/authors_handler.rs
@@ -1,7 +1,8 @@
 use helpers::state::AppState;
+use gateway::access_control::check_node_id_and_domain_header;
 
 use core::authors::*;
-use axum::{extract::State, Json};
+use axum::{extract::State, Json, http::{HeaderMap, StatusCode}};
 use serde::{Deserialize, Serialize};
 
 // Request bodies
@@ -73,81 +74,99 @@ pub struct VerifyAuthorResponse {
 // handler for listing authors
 pub async fn list_authors_handler(
     State(state): State<AppState>,
-) -> Result<Json<AuthorsListResponse>, (axum::http::StatusCode, String)> {
+    headers: HeaderMap,
+) -> Result<Json<AuthorsListResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match list_authors(state.docs.clone()).await {
         Ok(authors) => Ok(Json(AuthorsListResponse { authors })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
 // handler for getting the default author
 pub async fn get_default_author_handler(
     State(state): State<AppState>,
-) -> Result<Json<DefaultAuthorResponse>, (axum::http::StatusCode, String)> {
+    headers: HeaderMap,
+) -> Result<Json<DefaultAuthorResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match get_default_author(state.docs.clone()).await {
         Ok(author) => Ok(Json(DefaultAuthorResponse { default_author: author })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
 // handler for setting the default author
 pub async fn set_default_author_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<SetDefaultAuthorRequest>,
-) -> Result<Json<SetDefaultAuthorResponse>, (axum::http::StatusCode, String)> {
+) -> Result<Json<SetDefaultAuthorResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.author_id.is_empty() {
-        return Err((axum::http::StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
+        return Err((StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
     }
 
     match set_default_author(state.docs.clone(), payload.author_id).await {
         Ok(_) => Ok(Json(SetDefaultAuthorResponse {
             message: "Default author set successfully".to_string(),
         })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
 // handler for creating an author
 pub async fn create_author_handler(
     State(state): State<AppState>,
-) -> Result<Json<CreateAuthorResponse>, (axum::http::StatusCode, String)> {
+    headers: HeaderMap,
+) -> Result<Json<CreateAuthorResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match create_author(state.docs.clone()).await {
         Ok(author_id) => Ok(Json(CreateAuthorResponse { author_id })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
 // handler for deleting an author
 pub async fn delete_author_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<DeleteAuthorRequest>,
-) -> Result<Json<DeleteAuthorResponse>, (axum::http::StatusCode, String)> {
+) -> Result<Json<DeleteAuthorResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.author_id.is_empty() {
-        return Err((axum::http::StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
+        return Err((StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
     }
 
     match delete_author(state.docs.clone(), payload.author_id).await {
         Ok(()) => Ok(Json(DeleteAuthorResponse { 
             message: "Author deleted successfully".to_string()
         })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }
 
 // handler for verifying an author
 pub async fn verify_author_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<VerifyAuthorRequest>,
-) -> Result<Json<VerifyAuthorResponse>, (axum::http::StatusCode, String)> {
+) -> Result<Json<VerifyAuthorResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.author_id.is_empty() {
-        return Err((axum::http::StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
+        return Err((StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
     }
 
     match verify_author(state.docs.clone(), payload.author_id).await {
         Ok(is_valid) => Ok(Json(VerifyAuthorResponse { is_valid })),
-        Err(e) => Err((axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
 }

--- a/api/src/blobs_handler.rs
+++ b/api/src/blobs_handler.rs
@@ -6,9 +6,10 @@ use iroh_blobs::{
     util::SetTagOption,
     rpc::client::blobs::DownloadOptions,
 };
+use gateway::access_control::check_node_id_and_domain_header;
 
 use iroh::NodeAddr;
-use axum::{extract::State, Json};
+use axum::{extract::State, Json, http::HeaderMap};
 use bytes::Bytes;
 use serde::Deserialize;
 use serde::Serialize;
@@ -186,8 +187,11 @@ pub struct ExportBlobResponse {
 // Handler to add blob bytes
 pub async fn add_blob_bytes_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<AddBlobBytesRequest>,
 ) -> Result<Json<AddBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.content.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Content cannot be empty".to_string()));
@@ -212,8 +216,11 @@ pub async fn add_blob_bytes_handler(
 // Handler to add blob with a name
 pub async fn add_blob_named_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<AddBlobNamedRequest>,
 ) -> Result<Json<AddBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.content.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Content cannot be empty".to_string()));
@@ -242,8 +249,11 @@ pub async fn add_blob_named_handler(
 // Handler to add blob from a file path
 pub async fn add_blob_from_path_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<AddBlobFromPathRequest>,
 ) -> Result<Json<AddBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.file_path.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "File path cannot be empty".to_string()));
@@ -271,8 +281,11 @@ pub async fn add_blob_from_path_handler(
 // Handler to list blobs
 pub async fn list_blobs_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<ListBlobsRequest>,
 ) -> Result<Json<Vec<BlobInfoResponse>>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.page_size == 0 {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Page size must be greater than 0".to_string()));
@@ -300,8 +313,11 @@ pub async fn list_blobs_handler(
 // Handler to get a blob by hash
 pub async fn get_blob_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetBlobRequest>,
 ) -> Result<Json<GetBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -319,8 +335,11 @@ pub async fn get_blob_handler(
 // Handler to check the status of a blob
 pub async fn status_blob_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<StatusBlobRequest>,
 ) -> Result<Json<StatusBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -338,8 +357,11 @@ pub async fn status_blob_handler(
 // Handler to check if a blob exists
 pub async fn has_blob_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<HasBlobRequest>,
 ) -> Result<Json<HasBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -357,8 +379,11 @@ pub async fn has_blob_handler(
 // Handler to download a blob
 pub async fn download_blob_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<DownloadRequest>,
 ) -> Result<Json<DownloadOutcomeResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -384,8 +409,11 @@ pub async fn download_blob_handler(
 // This will not work right now as we have not implemented WarpOption for any function that can create a blob. If 'download_hash_sequence' is required then would need to add that. I think it would be a good feature to have, as then the user could create collections.
 pub async fn download_hash_sequence_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<DownloadRequest>,
 ) -> Result<Json<DownloadOutcomeResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -410,8 +438,11 @@ pub async fn download_hash_sequence_handler(
 // Handler to download a blob with options
 pub async fn download_with_options_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<DownloadWithOptionsRequest>,
 ) -> Result<Json<DownloadOutcomeResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if req.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));
@@ -483,7 +514,10 @@ pub async fn download_with_options_handler(
 // Handler to list tags
 pub async fn list_tags_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<TagInfoResponse>>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match list_tags(state.blobs.clone()).await {
         Ok(tags) => {
             let response = tags
@@ -507,8 +541,11 @@ pub async fn list_tags_handler(
 // Handler to delete a tag
 pub async fn delete_tag_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<DeleteTagRequest>,
 ) -> Result<Json<DeleteTagResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if req.tag_name.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Tag name cannot be empty".to_string()));
@@ -525,8 +562,11 @@ pub async fn delete_tag_handler(
 // Handler to export a blob to a file
 pub async fn export_blob_to_file_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<ExportBlobRequest>,
 ) -> Result<Json<ExportBlobResponse>, (axum::http::StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if req.hash.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "Hash cannot be empty".to_string()));

--- a/api/src/docs_handler.rs
+++ b/api/src/docs_handler.rs
@@ -1,9 +1,10 @@
 use core::docs::*;
 use helpers::state::AppState;
+use gateway::access_control::check_node_id_and_domain_header;
 
 use serde::{Deserialize, Serialize};
 use axum::{extract::State, Json};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, HeaderMap};
 use std::str::FromStr;
 use iroh_docs::{NamespaceId, CapabilityKind};
 use iroh_docs::rpc::client::docs::ShareMode;
@@ -252,8 +253,11 @@ pub struct GetDownloadPolicyResponse {
 // Handler for getting a document
 pub async fn get_document_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetDocumentRequest>,
 ) -> Result<Json<GetDocumentResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -274,8 +278,11 @@ pub async fn get_document_handler(
 // Handler for getting a blob entry
 pub async fn get_entry_blob_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetEntryBlobRequest>,
 ) -> Result<Json<GetEntryBlobResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.hash.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "hash cannot be empty".to_string()));
@@ -290,7 +297,10 @@ pub async fn get_entry_blob_handler(
 // Handler for creating a new document
 pub async fn create_doc_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<CreateDocResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match create_doc(state.docs.clone()).await {
         Ok(doc_id) => Ok(Json(CreateDocResponse { doc_id })),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
@@ -300,7 +310,10 @@ pub async fn create_doc_handler(
 // Handler for listing documents
 pub async fn list_docs_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
 ) -> Result<Json<Vec<ListDocsResponse>>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     match list_docs(state.docs.clone()).await {
         Ok(docs) => {
             let response = docs
@@ -327,8 +340,11 @@ pub async fn list_docs_handler(
 // Handler for dropping a document
 pub async fn drop_doc_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<DropDocRequest>,
 ) -> Result<Json<DropDocResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -345,8 +361,11 @@ pub async fn drop_doc_handler(
 // Handler for sharing a document
 pub async fn share_doc_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<ShareDocRequest>,
 ) -> Result<Json<ShareDocResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -383,8 +402,11 @@ pub async fn share_doc_handler(
 // Handler for joining a document
 pub async fn join_doc_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<JoinDocRequest>,
 ) -> Result<Json<JoinDocResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.ticket.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "ticket cannot be empty".to_string()));
@@ -399,8 +421,11 @@ pub async fn join_doc_handler(
 // Handler for closing a document
 pub async fn close_doc_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<CloseDocRequest>,
 ) -> Result<Json<CloseDocResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -432,8 +457,11 @@ pub async fn close_doc_handler(
 // { \"type\": \"object\", \"properties\": { \"owner\": { \"type\": \"string\" } }, \"required\": [\"owner\"] }
 pub async fn add_doc_schema_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<AddDocSchemaRequest>,
 ) -> Result<Json<AddDocSchemaResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.author_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "author_id cannot be empty".to_string()));
@@ -462,8 +490,11 @@ pub async fn add_doc_schema_handler(
 // "value": "{\"owner\": \"Dhiway\"}"
 pub async fn set_entry_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<SetEntryRequest>,
 ) -> Result<Json<SetEntryResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -496,8 +527,11 @@ pub async fn set_entry_handler(
 // Handler for setting an entry in a document from a file
 pub async fn set_entry_file_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<SetEntryFileRequest>,
 ) -> Result<Json<SetEntryFileResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -533,8 +567,11 @@ pub async fn set_entry_file_handler(
 // Handler for getting an entry from a document
 pub async fn get_entry_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetEntryRequest>,
 ) -> Result<Json<GetEntryResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -571,8 +608,11 @@ pub async fn get_entry_handler(
 // Handler for getting multiple entries from a document
 pub async fn get_entries_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetEntriesRequest>,
 ) -> Result<Json<Vec<GetEntryResponse>>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -609,8 +649,11 @@ pub async fn get_entries_handler(
 // Handler for deleting an entry from a document
 pub async fn delete_entry_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<DeleteEntryRequest>,
 ) -> Result<Json<DeleteEntryResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -636,8 +679,11 @@ pub async fn delete_entry_handler(
 // Handler for leaving a document
 pub async fn leave_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<LeaveRequest>,
 ) -> Result<Json<LeaveResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -654,8 +700,11 @@ pub async fn leave_handler(
 // Handler for getting the status of a document
 pub async fn status_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<StatusRequest>,
 ) -> Result<Json<StatusResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -674,8 +723,11 @@ pub async fn status_handler(
 // Handler for setting the download policy of a document
 pub async fn set_download_policy_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<SetDownloadPolicyRequest>,
 ) -> Result<Json<SetDownloadPolicyResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));
@@ -700,8 +752,11 @@ pub async fn set_download_policy_handler(
 // Handler for getting the download policy of a document
 pub async fn get_download_policy_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<GetDownloadPolicyRequest>,
 ) -> Result<Json<GetDownloadPolicyResponse>, (StatusCode, String)> {
+    check_node_id_and_domain_header(&headers)?;
+
     // request body checks
     if payload.doc_id.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "doc_id cannot be empty".to_string()));

--- a/api/src/gateway_handler.rs
+++ b/api/src/gateway_handler.rs
@@ -1,0 +1,200 @@
+use gateway::access_control::{
+    is_node_id_allowed, 
+    is_domain_allowed,
+    add_node_id,
+    remove_node_id,
+    add_domain,
+    remove_domain
+};
+use helpers::{
+    state::AppState,
+    utils::normalize_domain,
+};
+
+use serde::{Deserialize, Serialize};
+use axum::{extract::State, Json, debug_handler, http::StatusCode};
+use anyhow::Result;
+use iroh::NodeId;
+use std::str::FromStr;
+use regex::Regex;
+
+// Request bodies
+// 1. is_node_id_allowed
+#[derive(Deserialize)]
+pub struct IsNodeIdAllowedRequest {
+    pub node_id: String,
+}
+
+// 2. is_domain_allowed
+#[derive(Deserialize)]
+pub struct IsDomainAllowedRequest {
+    pub domain: String,
+}
+
+// 3. add_node_id
+#[derive(Deserialize)]
+pub struct AddNodeIdRequest {
+    pub node_id: String,
+}
+
+// 4. remove_node_id
+#[derive(Deserialize)]
+pub struct RemoveNodeIdRequest {
+    pub node_id: String,
+}
+
+// 5. add_domain
+#[derive(Deserialize)]
+pub struct AddDomainRequest {
+    pub domain: String,
+}
+
+// 6. remove_domain
+#[derive(Deserialize)]
+pub struct RemoveDomainRequest {
+    pub domain: String,
+}
+
+// Response bodies
+// 1. is_node_id_allowed
+#[derive(Serialize)]
+pub struct IsNodeIdAllowedResponse {
+    pub allowed: bool,
+}
+
+// 2. is_domain_allowed
+#[derive(Serialize)]
+pub struct IsDomainAllowedResponse {
+    pub allowed: bool,
+}  
+
+// 3. add_node_id
+#[derive(Serialize)]
+pub struct AddNodeIdResponse {
+    pub message: String,
+}
+
+// 4. remove_node_id
+#[derive(Serialize)]
+pub struct RemoveNodeIdResponse {
+    pub message: String,
+}
+
+// 5. add_domain
+#[derive(Serialize)]
+pub struct AddDomainResponse {
+    pub message: String,
+}
+
+// 6. remove_domain
+#[derive(Serialize)]
+pub struct RemoveDomainResponse {
+    pub message: String,
+}
+
+// Handler for checking if a node ID is allowed
+pub async fn is_node_id_allowed_handler(
+    Json(req): Json<IsNodeIdAllowedRequest>
+) -> Result<Json<IsNodeIdAllowedResponse>, (StatusCode, String)> {
+    if req.node_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId cannot be empty".to_string()));
+    }
+    if NodeId::from_str(&req.node_id).is_err() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId is not a valid NodeId".to_string()));
+    }
+
+
+    let allowed = is_node_id_allowed(&req.node_id);
+    Ok(Json(IsNodeIdAllowedResponse { allowed }))
+}
+
+// Handler for checking if a domain is allowed
+pub async fn is_domain_allowed_handler(
+    Json(req): Json<IsDomainAllowedRequest>
+) -> Result<Json<IsDomainAllowedResponse>, (StatusCode, String)> {
+    if req.domain.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "domain cannot be empty".to_string()));
+    }
+    let domain_regex = Regex::new(r"^(https?://)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$").unwrap();
+    if !domain_regex.is_match(&req.domain) {
+        return Err((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()));
+    }
+    
+    let normalized = normalize_domain(&req.domain)
+        .ok_or((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()))?;
+
+
+    let allowed = is_domain_allowed(&normalized);
+    Ok(Json(IsDomainAllowedResponse { allowed }))
+}
+
+// Handler for adding a node ID
+#[debug_handler]
+pub async fn add_node_id_handler(
+    Json(req): Json<AddNodeIdRequest>
+) -> Result<Json<AddNodeIdResponse>, (StatusCode, String)> {
+    if req.node_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId cannot be empty".to_string()));
+    }
+    if NodeId::from_str(&req.node_id).is_err() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId is not a valid NodeId".to_string()));
+    }
+
+    add_node_id(req.node_id.clone()).await;
+    Ok(Json(AddNodeIdResponse { message: "Node ID added successfully".to_string() }))
+}
+
+// Handler for removing a node ID
+pub async fn remove_node_id_handler(
+    Json(req): Json<RemoveNodeIdRequest>
+) -> Result<Json<RemoveNodeIdResponse>, (StatusCode, String)> {
+    if req.node_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId cannot be empty".to_string()));
+    }
+    if NodeId::from_str(&req.node_id).is_err() {
+        return Err((StatusCode::BAD_REQUEST, "nodeId is not a valid NodeId".to_string()));
+    }
+
+    remove_node_id(&req.node_id).await;
+    Ok(Json(RemoveNodeIdResponse { message: "Node ID removed successfully".to_string() }))
+}
+
+// Handler for adding a domain
+pub async fn add_domain_handler(
+    Json(req): Json<AddDomainRequest>
+) -> Result<Json<AddDomainResponse>, (StatusCode, String)> {
+    if req.domain.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "domain cannot be empty".to_string()));
+    }
+    // TODO: Add domain validation if necessary
+    let domain_regex = Regex::new(r"^(https?://)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$").unwrap();
+    if !domain_regex.is_match(&req.domain) {
+        return Err((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()));
+    }
+    
+    let normalized = normalize_domain(&req.domain)
+        .ok_or((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()))?;
+
+    add_domain(normalized.clone()).await;
+    Ok(Json(AddDomainResponse { message: "Domain added successfully".to_string() }))
+}
+
+// Handler for removing a domain
+pub async fn remove_domain_handler(
+    Json(req): Json<RemoveDomainRequest>
+) -> Result<Json<RemoveDomainResponse>, (StatusCode, String)> {
+    if req.domain.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "domain cannot be empty".to_string()));
+    }
+    // TODO: Add domain validation if necessary
+    let domain_regex = Regex::new(r"^(https?://)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$").unwrap();
+    if !domain_regex.is_match(&req.domain) {
+        return Err((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()));
+    }
+    
+    let normalized = normalize_domain(&req.domain)
+        .ok_or((StatusCode::BAD_REQUEST, "Invalid domain format".to_string()))?;
+
+    remove_domain(&normalized).await;
+    Ok(Json(RemoveDomainResponse { message: "Domain removed successfully".to_string() }))
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod authors_handler;
 pub mod blobs_handler;
 pub mod docs_handler;
+pub mod gateway_handler;

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -15,3 +15,4 @@ axum = { version = "0.7.9", features = ["multipart", "macros"] }
 node = { path = "../node" }
 router = { path = "../router" }
 helpers = { path = "../helpers" }
+gateway = { path = "../gateway" }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -5,6 +5,10 @@ use helpers::{
     frontend::start_frontend,
     state::AppState,
 };
+use gateway::{
+    storage::init_access_control,
+    access_control::{set_storage_path, ensure_self_node_id_allowed},
+};
 
 use tokio::signal;
 use std::error::Error;
@@ -17,10 +21,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = CliArgs::parse();
 
     // Initialize the Iroh node
-    let iroh_node: IrohNode = setup_iroh_node(args).await?;
+    let iroh_node: IrohNode = setup_iroh_node(args.clone()).await?;
+
+    // Initialize gateway
+    let path = args.path.unwrap();
+    let path_str = path.to_str().unwrap();
+    let (mut allowed_node_ids, allowed_domains) = init_access_control(path_str).await?;
+
+    // Ensure self NodeId is added on first run
+    ensure_self_node_id_allowed(
+        &path_str.to_string().clone(), 
+        iroh_node.node_id.to_string().clone(), 
+        &mut allowed_node_ids
+    ).await?;
+
+    set_storage_path(
+        path_str.to_string(), 
+        allowed_node_ids, 
+        allowed_domains
+    );
 
     // Start frontend
-    start_frontend();
+    // start_frontend();
 
     println!("Iroh node started!");
     println!("Your NodeId: {}", iroh_node.node_id);
@@ -32,8 +54,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let app = create_router(state);
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:4000").await?;
-    println!("Server started on http://localhost:4000");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:4001").await?;
+    println!("Server started on http://localhost:4001");
 
     axum::serve(listener, app).await?;
     

--- a/core/src/docs.rs
+++ b/core/src/docs.rs
@@ -386,6 +386,7 @@ pub async fn add_doc_schema(
 
     let key = "schema";
     let encoded_key = encode_key(key.as_bytes());
+    // let encoded_key = key.as_bytes().to_vec();
 
     let updated_hash = doc
         .set_bytes(

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gateway"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lazy_static = "1.4"
+tokio = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+axum = { version = "0.7.9", features = ["multipart", "macros"] }
+
+helpers = { path = "../helpers" }

--- a/gateway/src/access_control.rs
+++ b/gateway/src/access_control.rs
@@ -1,0 +1,137 @@
+use crate::storage::{save_set};
+use helpers::utils::normalize_domain;
+
+use std::collections::HashSet;
+use std::sync::RwLock;
+use lazy_static::lazy_static;
+use axum::http::{HeaderMap, StatusCode};
+
+lazy_static! {
+    static ref NODE_IDS: RwLock<HashSet<String>> = RwLock::new(HashSet::new());
+    static ref DOMAINS: RwLock<HashSet<String>> = RwLock::new(HashSet::new());
+}
+
+static mut STORAGE_PATH: Option<String> = None;
+
+pub fn set_storage_path(path: String, node_ids: HashSet<String>, domains: HashSet<String>) {
+    unsafe {
+        STORAGE_PATH = Some(path);
+    }
+    *NODE_IDS.write().unwrap() = node_ids;
+    *DOMAINS.write().unwrap() = domains;
+}
+
+pub fn is_node_id_allowed(node_id: &str) -> bool {
+    NODE_IDS.read().unwrap().contains(node_id)
+}
+
+pub fn is_domain_allowed(domain: &str) -> bool {
+    DOMAINS.read().unwrap().contains(domain)
+}
+
+pub async fn add_node_id(node_id: String) {
+    {
+        let mut ids = NODE_IDS.write().unwrap();
+        ids.insert(node_id.clone());
+        // lock is dropped here
+    }
+    let ids_snapshot = {
+        let ids = NODE_IDS.read().unwrap();
+        ids.clone()
+    };
+    save("allowed_node_ids.json", &ids_snapshot).await;
+}
+
+pub async fn remove_node_id(node_id: &str) {
+    {
+        let mut ids = NODE_IDS.write().unwrap();
+        ids.remove(node_id);
+        // lock is dropped here
+    }
+    let ids_snapshot = {
+        let ids = NODE_IDS.read().unwrap();
+        ids.clone()
+    };
+    save("allowed_node_ids.json", &ids_snapshot).await;
+}
+
+pub async fn add_domain(domain: String) {
+    {
+        let mut domains = DOMAINS.write().unwrap();
+        domains.insert(domain.clone());
+        // lock is dropped here
+    }
+    let domains_snapshot = {
+        let domains = DOMAINS.read().unwrap();
+        domains.clone()
+    };
+    save("allowed_domains.json", &domains_snapshot).await;
+}
+
+pub async fn remove_domain(domain: &str) {
+    {
+        let mut domains = DOMAINS.write().unwrap();
+        domains.remove(domain);
+        // lock is dropped here
+    }
+    let domains_snapshot = {
+        let domains = DOMAINS.read().unwrap();
+        domains.clone()
+    };
+    save("allowed_domains.json", &domains_snapshot).await;
+}
+
+async fn save(filename: &str, set: &HashSet<String>) {
+    if let Some(path) = unsafe { STORAGE_PATH.clone() } {
+        let _ = save_set(&path, filename, set).await;
+    }
+}
+
+pub async fn ensure_self_node_id_allowed(path: &str, node_id: String, node_ids: &mut HashSet<String>) -> anyhow::Result<()> {
+    if node_ids.is_empty() {
+        println!("First run: Adding node's own NodeId to allowed list.");
+        node_ids.insert(node_id.clone());
+        save_set(path, "allowed_node_ids.json", node_ids).await?;
+    }
+    Ok(())
+}
+
+// Check if the request has a valid nodeId header
+// TODO: add check for domain too
+pub fn check_node_id_and_domain_header(headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
+    let node_id = headers.get("nodeId").and_then(|v| v.to_str().ok());
+    let origin = headers.get("Origin").and_then(|v| v.to_str().ok());
+
+    match (node_id, origin) {
+        (Some(nid), None) => {
+            if !is_node_id_allowed(nid) {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    "Access denied for this nodeId".to_string(),
+                ));
+            }
+        }
+        (None, Some(origin_str)) => {
+            let domain = normalize_domain(origin_str)
+                .ok_or((StatusCode::BAD_REQUEST, "Invalid Origin header format".to_string()))?;
+
+            if !is_domain_allowed(&domain) {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    format!("Access denied for domain: {}", domain),
+                ));
+            }
+        }
+        (Some(_), Some(_)) => {
+            // TODO: Handle case where both nodeId and Origin are provided
+        }
+        (None, None) => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                "Missing both nodeId and Origin headers".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod storage;
+pub mod access_control;

--- a/gateway/src/storage.rs
+++ b/gateway/src/storage.rs
@@ -1,0 +1,40 @@
+use std::{collections::HashSet, path::PathBuf};
+use tokio::fs;
+use serde::{Serialize, Deserialize};
+use anyhow;
+
+#[derive(Serialize, Deserialize)]
+struct PersistentData {
+    node_ids: HashSet<String>,
+    domains: HashSet<String>,
+}
+
+/// Initialize data directory and load access control lists
+pub async fn init_access_control(path: &str) -> anyhow::Result<(HashSet<String>, HashSet<String>)> {
+    let path = PathBuf::from(path);
+    fs::create_dir_all(&path).await?;
+
+    let node_ids = load_set(path.join("allowed_node_ids.json")).await.unwrap_or_default();
+    let domains = load_set(path.join("allowed_domains.json")).await.unwrap_or_default();
+
+    Ok((node_ids, domains))
+}
+
+/// Load a set from a JSON file
+async fn load_set(file: PathBuf) -> anyhow::Result<HashSet<String>> {
+    if !file.exists() {
+        return Ok(HashSet::new());
+    }
+
+    let content = fs::read_to_string(file).await?;
+    let set: HashSet<String> = serde_json::from_str(&content)?;
+    Ok(set)
+}
+
+/// Write a set to a JSON file
+pub async fn save_set(path: &str, filename: &str, set: &HashSet<String>) -> anyhow::Result<()> {
+    let file_path = PathBuf::from(path).join(filename);
+    let json = serde_json::to_string_pretty(set)?;
+    fs::write(file_path, json).await?;
+    Ok(())
+}

--- a/helpers/src/cli.rs
+++ b/helpers/src/cli.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 // # Run with persistent path and custom secret key
 // cargo run -- --path <path> --secret-key <your_secret_key>
 // ```
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(name = "Starter Kit")]
 #[command(about = "A starter kit for data providers", long_about = None)]
 pub struct CliArgs {

--- a/helpers/src/utils.rs
+++ b/helpers/src/utils.rs
@@ -159,3 +159,8 @@ pub async fn validate_key(
 
     Ok(())
 }
+
+pub fn normalize_domain(input: &str) -> Option<String> {
+    let no_scheme = input.trim().trim_start_matches("http://").trim_start_matches("https://");
+    no_scheme.split('/').next().map(|s| s.to_lowercase())
+}

--- a/router/src/router.rs
+++ b/router/src/router.rs
@@ -2,6 +2,7 @@ use api::{
     authors_handler::*,
     blobs_handler::*,
     docs_handler::*,
+    gateway_handler::*
 };
 use helpers::state::AppState;
 
@@ -17,7 +18,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/blobs/get-blob", get(get_blob_handler))
         .route("/blobs/status-blob", get(status_blob_handler))
         .route("/blobs/has-blob", get(has_blob_handler))
-        .route("/blobs/download-blob", get(download_blob_handler))
+        .route("/blobs/download-blob", post(download_blob_handler))
         .route("/blobs/download-hash-sequence", get(download_hash_sequence_handler))
         .route("/blobs/download-with-options", get(download_with_options_handler))
         .route("/blobs/list-tags", get(list_tags_handler))
@@ -47,6 +48,12 @@ pub fn create_router(state: AppState) -> Router {
         .route("/docs/status", get(status_handler))
         .route("/docs/set-download-policy", post(set_download_policy_handler))
         .route("/docs/get-download-policy", get(get_download_policy_handler))
+        .route("/gateway/is-node-id-allowed", get(is_node_id_allowed_handler))
+        .route("/gateway/is-domain-allowed", get(is_domain_allowed_handler))
+        .route("/gateway/add-node-id", post(add_node_id_handler))
+        .route("/gateway/remove-node-id", post(remove_node_id_handler))
+        .route("/gateway/add-domain", post(add_domain_handler))
+        .route("/gateway/remove-domain", post(remove_domain_handler))
         .with_state(state)
         .layer(CorsLayer::very_permissive())
 }


### PR DESCRIPTION
In this commit:
-> gateway's ```access_control.rs``` and ```storage.rs``` have been added.
-> gateway's handler functions have been created
-> gateway's endpoints have been added to the router/
-> a check for request headers(for 'Origin' and 'nodeId') have been added to each API handler function
-> allowed nodeIds and domains are persistent in nature, they will not be lost on node shutdown. 